### PR TITLE
add variable crop target length

### DIFF
--- a/borzoi_pytorch/config_borzoi.py
+++ b/borzoi_pytorch/config_borzoi.py
@@ -16,6 +16,7 @@ class BorzoiConfig(PretrainedConfig):
         attn_dropout = 0.05,
         pos_dropout = 0.01,
         enable_mouse_head = False,
+        bins_to_return = 6144,
         **kwargs,
     ):
         self.dim = dim
@@ -29,4 +30,5 @@ class BorzoiConfig(PretrainedConfig):
         self.pos_dropout = pos_dropout
         self.return_center_bins_only = return_center_bins_only
         self.enable_mouse_head = enable_mouse_head
+        self.bins_to_return = bins_to_return
         super().__init__(**kwargs)

--- a/borzoi_pytorch/pytorch_borzoi_model.py
+++ b/borzoi_pytorch/pytorch_borzoi_model.py
@@ -146,7 +146,7 @@ class Borzoi(PreTrainedModel):
         )
         self.separable0 = ConvBlock(in_channels = config.dim, out_channels = config.dim,  kernel_size = 3, conv_type = 'separable')
         if config.return_center_bins_only:
-            self.crop = TargetLengthCrop(6144)
+            self.crop = TargetLengthCrop(config.bins_to_return)
         else:
             self.crop = TargetLengthCrop(16384 - 32) # as in Borzoi     
         self.final_joined_convs = nn.Sequential(


### PR DESCRIPTION
### Description

Adds short sequence compatibility to Borzoi model by allowing users to set a target crop length. 

Fixes #12. (Remove this line if the PR is only fixing part of the issue)

### Type of change

Please select the relevant options.

- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Code refactoring (non-breaking change which improves code quality)
- [ ] Formatting (update pre-commit hooks, linting, etc.)
- [ ] New data (only experimental data or small scale design sequences/structures)
- [ ] New documentation (non-breaking change which adds clarity to the codebase)
- [x] New feature (non-breaking change which adds functionality)

### Checklist:

- [x] I have performed a self-review of my code.
- [ ] I have made corresponding changes to the documentation.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] New and existing tests pass locally with my changes.